### PR TITLE
added edit to gallery img links to grab "huge" thumbnails

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -38,7 +38,7 @@ function getImagesFunc() {
 
             //loop until it goes through full json or until our array has 10 img links. shorter of the 2
             for (var i = 0; i < response.data.length && imageLinkArr.length < 10; i++) {
-                var imgLink = response.data[i].link.slice(0, 4) + "s" + response.data[i].link.slice(4);
+                var imgLink = response.data[i].link.slice(0, 4) + "s" + response.data[i].link.slice(4,-4)+ "h" + response.data[i].link.slice(response.data[i].link.length - 4);
                 console.log('imglink ' + imgLink)
                 var height = response.data[i].height;
                 var width = response.data[i].width;
@@ -59,11 +59,10 @@ function getImagesFunc() {
 
             console.log(imageLinkArr);
             console.log(response);
-            console.log('json url ' + queryURL);
-
-            console.log("imgArr 2 " + imageLinkArr)
+            console.log('imgur json url ' + queryURL);
 
             shuffle(imageLinkArr);
+            console.log('image array '+imageLinkArr)
            
             for (var i = 0; i < imageLinkArr.length; i++) {
                 $("#img" + i).attr("src", imageLinkArr[i]);


### PR DESCRIPTION
added extra splices to insert "h" at the end of the image link file names, which grabs "huge" thumbnails (1024x1024) from imgur instead of the full resolution files. they will be big enough to fit the carousel, and prevent the program from unnecessarily loading images at full resolutions (i.e if the original image resolution is like 4000x6000 or something, will grab a thumbnail that is like a 4th of that size).

expecting to improve loading times for gallery overall